### PR TITLE
delete (:Game) to rdfs:List

### DIFF
--- a/Properties.ttl
+++ b/Properties.ttl
@@ -88,8 +88,9 @@
 
 :hasGames a rdfs:Property;
   rdfs:domain :Match;
-  rdfs:range (:Game);
-  rdfs:label "Liste des parties composant le match".
+  rdfs:range rdfs:List;
+  rdfs:label "Liste des parties composant le match";
+  rdfs:comment "La liste contient des Games".
 
 :hasPlayed a rdfs:Property;
   rdfs:domain :Match;


### PR DESCRIPTION
erreur de syntaxe sur la définition de la List
rdfs:comment "La liste contient des Games".